### PR TITLE
bug fixes for group command, and some cleanup

### DIFF
--- a/src/models/group.js
+++ b/src/models/group.js
@@ -30,8 +30,12 @@ module.exports = function() {
 		this.model('Group').updateOne({_id: this.id},{numMembers: this.numMembers-1}).exec();
 	};
 
-	groupSchema.statics.findGroupByName = function(name) {
-		return this.findOne({name: new RegExp(name, 'i')}).exec();
+	groupSchema.statics.findGroupByName = async function(name) {
+		// A bit of a workaround, couldn't use $where due to variable scope restrictions
+		// https://docs.mongodb.com/manual/reference/operator/query/where/#restrictions
+		const groups = await this.find().exec();
+		const regex = new RegExp(CoreUtil.stripPunctuation(name), 'i');
+		return groups.find(group => regex.test(CoreUtil.stripPunctuation(group.name)));
 	};
 
 	groupSchema.statics.findAllGroups = function() {

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -59,6 +59,10 @@ function formatArgsForFile(args) {
 	return args.join(" ") + "\n";
 }
 
+function stripPunctuation(text) {
+	return text.replace(/[^\w\s]/g, "");
+}
+
 module.exports = {
 	dateError,
 	dateLog,
@@ -66,5 +70,6 @@ module.exports = {
 	dateDebugError,
 	isMemberAdmin,
 	doFormatting,
-	isNumber
+	isNumber,
+	stripPunctuation
 };


### PR DESCRIPTION
Changes:
- If only 1 member, show `1 member` instead of `1 members`
- Show `Group does not exist` rather than `Role does not exist` (will still show `Role does not exist` in the unlikely event that group exists but role doesn't)
- The bot will now always have proper casing on the group name in its reply, i.e. `Removed you from group Don't Starve` instead of `Removed you from group don't starve`
- Ignore punctuation, so `!group dont starve` and `!group don’t starve` (smart quote) will both work

Refactor:
- Make `findGroupByName` handle all of the casing consistency to not have .toLowercase, .trim everywhere
- Use async/await instead of promises