### PR TITLE
Improve error handling

### DIFF
--- a/src/HandleGuildMessage.js
+++ b/src/HandleGuildMessage.js
@@ -52,7 +52,10 @@ function handleGuildCommand(client, message, commands, guildData) {
 				}
 			}
 		})
-		.catch(err => err && message.reply(err));
+		.catch(err => {
+			console.error(err);
+			message.reply("An error occurred.");
+		});
 	}
 }
 


### PR DESCRIPTION
Currently when there is an error thrown from a command invocation, the bot will reply with a blank message, and nothing shows in the console. This changes that so the bot will say "An error occurred." and the error stack trace will show up in the console.error